### PR TITLE
Ticket1767 use cv to do homing

### DIFF
--- a/motorApp/MclennanSrc/devPM304.cc
+++ b/motorApp/MclennanSrc/devPM304.cc
@@ -66,6 +66,7 @@ STATIC long PM304_init_record(void *);
 STATIC long PM304_start_trans(struct motorRecord *);
 STATIC RTN_STATUS PM304_build_trans(motor_cmnd, double *, struct motorRecord *);
 STATIC RTN_STATUS PM304_end_trans(struct motorRecord *);
+STATIC long VELO;
 
 struct motor_dset devPM304 =
 {
@@ -232,14 +233,18 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
         if (cntrl->model == MODEL_PM304){
            sprintf(buff, "%dIX;", axis);
         } else {
-           sprintf(buff, "%dHD;", axis);
+           //sprintf(buff, "%dHD;", axis);
+		   // Motor always sends an SV before CV for VELO will be current base velocity
+		   sprintf(buff, "%dCV%ld;", axis, VELO);
         }
         break;
     case HOME_REV:
         if (cntrl->model == MODEL_PM304){
            sprintf(buff, "%dIX-1;", axis);
         } else {
-           sprintf(buff, "%dHD-1;", axis);
+           //sprintf(buff, "%dHD-1;", axis);
+		   // Motor always sends an SV before CV for VELO will be current base velocity
+		   sprintf(buff, "%dCV-%ld;", axis, VELO);
         }
         break;
     case LOAD_POS:
@@ -253,10 +258,10 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
         break;          /* PM304 does not use base velocity */
     case SET_VELOCITY:
         sprintf(buff, "%dSV%ld;", axis, ival);
+		VELO = ival;
         break;
     case SET_ACCEL:
         sprintf(buff, "%dSA%ld;", axis, ival);
-        strcat(motor_call->message, buff);
         sprintf(buff, "%dSD%ld;", axis, ival);
         break;
     case GO:

--- a/motorApp/MclennanSrc/devPM304.cc
+++ b/motorApp/MclennanSrc/devPM304.cc
@@ -66,7 +66,7 @@ STATIC long PM304_init_record(void *);
 STATIC long PM304_start_trans(struct motorRecord *);
 STATIC RTN_STATUS PM304_build_trans(motor_cmnd, double *, struct motorRecord *);
 STATIC RTN_STATUS PM304_end_trans(struct motorRecord *);
-STATIC long VELO;
+STATIC long VELO = 0;
 
 struct motor_dset devPM304 =
 {

--- a/motorApp/MclennanSrc/devPM304.cc
+++ b/motorApp/MclennanSrc/devPM304.cc
@@ -262,6 +262,7 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
         break;
     case SET_ACCEL:
         sprintf(buff, "%dSA%ld;", axis, ival);
+        strcat(motor_call->message, buff);
         sprintf(buff, "%dSD%ld;", axis, ival);
         break;
     case GO:

--- a/motorApp/MclennanSrc/devPM304.cc
+++ b/motorApp/MclennanSrc/devPM304.cc
@@ -16,7 +16,7 @@
  *                              motorRecord
  * .03  02-11-03        mlr     Version 3.0, added support for PM600 model.
  *                              Added SD for decceleration.
- * .04  05/27/03 	rls 	R3.14 conversion.
+ * .04  05/27/03    rls     R3.14 conversion.
  *      ...
  */
 
@@ -24,12 +24,12 @@
 #define VERSION 3.00
 
 
-#include 	<string.h>
+#include    <string.h>
 #include        "motorRecord.h"
 #include        "motor.h"
 #include        "motordevCom.h"
 #include        "drvPM304.h"
-#include 	"epicsExport.h"
+#include    "epicsExport.h"
 
 #define STATIC static
 
@@ -121,7 +121,7 @@ STATIC long PM304_init(void *arg)
 
     if (after == 0)
     {
-	drvtabptr = &PM304_access;
+    drvtabptr = &PM304_access;
         (drvtabptr->init)();
     }
 
@@ -234,8 +234,8 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
            sprintf(buff, "%dIX;", axis);
         } else {
            //sprintf(buff, "%dHD;", axis);
-		   // Motor always sends an SV before CV for VELO will be current base velocity
-		   sprintf(buff, "%dCV%ld;", axis, VELO);
+           // Motor always sends an SV before CV for VELO will be current base velocity
+           sprintf(buff, "%dCV%ld;", axis, VELO);
         }
         break;
     case HOME_REV:
@@ -243,8 +243,8 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
            sprintf(buff, "%dIX-1;", axis);
         } else {
            //sprintf(buff, "%dHD-1;", axis);
-		   // Motor always sends an SV before CV for VELO will be current base velocity
-		   sprintf(buff, "%dCV-%ld;", axis, VELO);
+           // Motor always sends an SV before CV for VELO will be current base velocity
+           sprintf(buff, "%dCV-%ld;", axis, VELO);
         }
         break;
     case LOAD_POS:
@@ -258,7 +258,7 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
         break;          /* PM304 does not use base velocity */
     case SET_VELOCITY:
         sprintf(buff, "%dSV%ld;", axis, ival);
-		VELO = ival;
+        VELO = ival;
         break;
     case SET_ACCEL:
         sprintf(buff, "%dSA%ld;", axis, ival);


### PR DESCRIPTION
Use the CV command instead of HD to do homing. Use the velocity set at the previous SV command, which always directly precedes the homing command. This change was requested for the November 2016 cycle. The intention is to integrate more complex behaviour later as part of ticket.

---

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1767

### Acceptance criteria

McLennan can be started and the homing velocity set via the VELO macro

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [ ] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section