### PR TITLE
Hard limits now set by soft limit values. Changed overshoot behaviour…

### DIFF
--- a/motorApp/MotorSimSrc/motorSimDriver.cpp
+++ b/motorApp/MotorSimSrc/motorSimDriver.cpp
@@ -376,6 +376,24 @@ asynStatus motorSimAxis::poll(bool *moving)
 }
 
 
+/** Set the high limit position of the motor.
+  * \param[in] highLimit The new high limit position that should be set in the hardware. Units=steps.*/
+asynStatus motorSimAxis::setHighLimit(double highLimit)
+{
+  hiHardLimit_ = highLimit;
+  return asynSuccess;
+}
+
+
+/** Set the low limit position of the motor.
+  * \param[in] lowLimit The new low limit position that should be set in the hardware. Units=steps.*/
+asynStatus motorSimAxis::setLowLimit(double lowLimit)
+{
+  lowHardLimit_ = lowLimit;
+  return asynSuccess;
+}
+
+
 /** Process one iteration of an axis
 
   This routine takes a single axis and propogates its motion forward a given amount
@@ -407,14 +425,16 @@ void motorSimAxis::process(double delta )
     endpoint_.axis[0].p = home_;
     endpoint_.axis[0].v = 0.0;
   }
+  
+  route_pars_t pars;
+  routeGetParams(route_, &pars);
+  
   if ( nextpoint_.axis[0].p > hiHardLimit_ && nextpoint_.axis[0].v > 0 )
   {
     if (homing_) setVelocity(-endpoint_.axis[0].v, 0.0 );
     else
     {
-      reroute_ = ROUTE_NEW_ROUTE;
-      endpoint_.axis[0].p = hiHardLimit_;
-      endpoint_.axis[0].v = 0.0;
+	  stop(pars.axis[0].Amax);
     }
   }
   else if (nextpoint_.axis[0].p < lowHardLimit_ && nextpoint_.axis[0].v < 0)
@@ -422,9 +442,7 @@ void motorSimAxis::process(double delta )
     if (homing_) setVelocity(-endpoint_.axis[0].v, 0.0 );
     else
     {
-      reroute_ = ROUTE_NEW_ROUTE;
-      endpoint_.axis[0].p = lowHardLimit_;
-      endpoint_.axis[0].v = 0.0;
+	  stop(pars.axis[0].Amax);
     }
   }
 

--- a/motorApp/MotorSimSrc/motorSimDriver.h
+++ b/motorApp/MotorSimSrc/motorSimDriver.h
@@ -31,6 +31,9 @@ public:
   asynStatus stop(double acceleration);
   asynStatus poll(bool *moving);
   asynStatus setPosition(double position);
+  asynStatus setHighLimit(double highLimit);
+  asynStatus setLowLimit(double lowLimit);
+
 
   /* These are the methods that are new to this class */
   asynStatus config(int hiHardLimit, int lowHardLimit, int home, int start);


### PR DESCRIPTION
... to stop and overshoot, instead of overshooting then correcting.

To test:
- Set high and low software limits.
- Move to each limit - a limit violation should be displayed
- Move to the limit, but before motion has finished, move the limit closer - the motor should stop

https://github.com/ISISComputingGroup/IBEX/issues/1891#event-885134146