### PR TITLE
Add config xml with IOC description

### DIFF
--- a/iocBoot/iocmotorSim/config.xml
+++ b/iocBoot/iocmotorSim/config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<ioc_desc>Simulated motor</ioc_desc>
+</config_part>
+</ioc_config>


### PR DESCRIPTION
### Description of work

Add missing config.xml containing IOC description

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2048

### Acceptance criteria

The IOC description is shown in the IOC dialog box/configuration editor in the GUI. Note that a `make iocstartups` will be required.
