### PR TITLE
Ticket2021 mc lennan stuck on multiple homes

### DIFF
--- a/motorApp/MclennanSrc/MclennanRegister.cc
+++ b/motorApp/MclennanSrc/MclennanRegister.cc
@@ -33,13 +33,14 @@ static const iocshArg setupArg1 = {"Polling rate", iocshArgInt};
 static const iocshArg configArg0 = {"Card being configured", iocshArgInt};
 static const iocshArg configArg1 = {"asyn port name", iocshArgString};
 static const iocshArg configArg2 = {"Number of axes", iocshArgInt};
+static const iocshArg configArg3 = {"Combined home modes for all axes", iocshArgInt};
 
 static const iocshArg * const PM304SetupArgs[2]  = {&setupArg0, &setupArg1};
-static const iocshArg * const PM304ConfigArgs[3] = {&configArg0, &configArg1,
-    &configArg2};
+static const iocshArg * const PM304ConfigArgs[4] = {&configArg0, &configArg1,
+    &configArg2, &configArg3};
 
 static const iocshFuncDef setupPM304  = {"PM304Setup",  2, PM304SetupArgs};
-static const iocshFuncDef configPM304 = {"PM304Config", 3, PM304ConfigArgs};
+static const iocshFuncDef configPM304 = {"PM304Config", 4, PM304ConfigArgs};
 
 static void setupPM304CallFunc(const iocshArgBuf *args)
 {
@@ -47,7 +48,7 @@ static void setupPM304CallFunc(const iocshArgBuf *args)
 }
 static void configPM304CallFunc(const iocshArgBuf *args)
 {
-    PM304Config(args[0].ival, args[1].sval, args[2].ival);
+    PM304Config(args[0].ival, args[1].sval, args[2].ival, args[3].ival);
 }
 
 static void MclennanRegister(void)

--- a/motorApp/MclennanSrc/devPM304.cc
+++ b/motorApp/MclennanSrc/devPM304.cc
@@ -242,7 +242,7 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
 			int motor_default=0, constant_velocity=1, n_modes = 2;
 			//int band = pow(double(n_modes), axis-1);
 			//int home_mode = int((1 % band)/band);
-			int home_mode = 1;
+			int home_mode = 0;
 			if ( home_mode==motor_default ) {
 				sprintf(buff, "%dHD%d;", axis, home_direction);
 			} else {

--- a/motorApp/MclennanSrc/devPM304.cc
+++ b/motorApp/MclennanSrc/devPM304.cc
@@ -243,7 +243,8 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
 			// Based on 32-bit integer, splitting across 8 axis. 4 bits -> 8 modes
 			int n_modes = 8;
 			int band = pow(double(n_modes), axis-1);
-			int home_mode = int(cntrl->home_modes/float(band)) % band;
+			int home_mode = int(cntrl->home_modes/float(band)) % n_modes;
+			printf("Homing axis %i using mode %i\n", axis, home_mode);
 			if ( home_mode==motor_default || home_mode==reverse_and_zero ) {
 				if ( home_mode==reverse_and_zero ) {
 					home_direction = -1;

--- a/motorApp/MclennanSrc/devPM304.cc
+++ b/motorApp/MclennanSrc/devPM304.cc
@@ -25,6 +25,7 @@
 
 
 #include    <string.h>
+#include    <math.h>
 #include        "motorRecord.h"
 #include        "motor.h"
 #include        "motordevCom.h"
@@ -221,6 +222,8 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
             break;
     }
 
+	int home_direction = 1;
+	
     switch (command)
     {
     case MOVE_ABS:
@@ -229,17 +232,23 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
     case MOVE_REL:
         sprintf(buff, "%dMR%ld;", axis, ival);
         break;
+    case HOME_REV:
+		home_direction = -1;
     case HOME_FOR:
         if (cntrl->model == MODEL_PM304){
-           sprintf(buff, "%dIX;", axis);
-        }
-		/*  Homing for PM600 done via SNL. See homing.st */
-        break;
-    case HOME_REV:
-        if (cntrl->model == MODEL_PM304){
-           sprintf(buff, "%dIX-1;", axis);
+           sprintf(buff, "%dIX%d;", axis, home_direction);
         } 
-		/*  Homing for PM600 done via SNL. See homing.st */
+		else {
+			int motor_default=0, constant_velocity=1, n_modes = 2;
+			//int band = pow(double(n_modes), axis-1);
+			//int home_mode = int((1 % band)/band);
+			int home_mode = 1;
+			if ( home_mode==motor_default ) {
+				sprintf(buff, "%dHD%d;", axis, home_direction);
+			} else {
+				// Let SNL take care of it
+			}
+		}
         break;
     case LOAD_POS:
         if (cntrl->use_encoder[axis-1]){

--- a/motorApp/MclennanSrc/devPM304.cc
+++ b/motorApp/MclennanSrc/devPM304.cc
@@ -25,7 +25,6 @@
 
 
 #include    <string.h>
-#include    <math.h>
 #include        "motorRecord.h"
 #include        "motor.h"
 #include        "motordevCom.h"
@@ -240,11 +239,7 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
         } 
 		else {
 			int motor_default=0, constant_velocity=1, reverse_and_zero=2;
-			// Based on 32-bit integer, splitting across 8 axis. 4 bits -> 8 modes
-			int n_modes = 8;
-			int band = pow(double(n_modes), axis-1);
-			int home_mode = int(cntrl->home_modes/float(band)) % n_modes;
-			printf("Homing axis %i using mode %i\n", axis, home_mode);
+			int home_mode = cntrl->home_mode[axis-1];
 			if ( home_mode==motor_default || home_mode==reverse_and_zero ) {
 				if ( home_mode==reverse_and_zero ) {
 					home_direction = -1;

--- a/motorApp/MclennanSrc/devPM304.cc
+++ b/motorApp/MclennanSrc/devPM304.cc
@@ -239,10 +239,11 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
            sprintf(buff, "%dIX%d;", axis, home_direction);
         } 
 		else {
-			int motor_default=0, constant_velocity=1, reverse_and_zero=2, n_modes = 3;
-			//int band = pow(double(n_modes), axis-1);
-			//int home_mode = int((1 % band)/band);
-			int home_mode = 2;
+			int motor_default=0, constant_velocity=1, reverse_and_zero=2;
+			// Based on 32-bit integer, splitting across 8 axis. 4 bits -> 8 modes
+			int n_modes = 8;
+			int band = pow(double(n_modes), axis-1);
+			int home_mode = int(cntrl->home_modes/float(band)) % band;
 			if ( home_mode==motor_default || home_mode==reverse_and_zero ) {
 				if ( home_mode==reverse_and_zero ) {
 					home_direction = -1;

--- a/motorApp/MclennanSrc/devPM304.cc
+++ b/motorApp/MclennanSrc/devPM304.cc
@@ -239,14 +239,17 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
            sprintf(buff, "%dIX%d;", axis, home_direction);
         } 
 		else {
-			int motor_default=0, constant_velocity=1, n_modes = 2;
+			int motor_default=0, constant_velocity=1, reverse_and_zero=2, n_modes = 3;
 			//int band = pow(double(n_modes), axis-1);
 			//int home_mode = int((1 % band)/band);
-			int home_mode = 0;
-			if ( home_mode==motor_default ) {
+			int home_mode = 2;
+			if ( home_mode==motor_default || home_mode==reverse_and_zero ) {
+				if ( home_mode==reverse_and_zero ) {
+					home_direction = -1;
+				}
 				sprintf(buff, "%dHD%d;", axis, home_direction);
 			} else {
-				// Let SNL take care of it
+				// Let SNL take care of everything. See homing.st
 			}
 		}
         break;

--- a/motorApp/MclennanSrc/drvPM304.cc
+++ b/motorApp/MclennanSrc/drvPM304.cc
@@ -32,6 +32,7 @@
 
 
 #include    <string.h>
+#include    <math.h>
 #include    <stdio.h>
 #include    <epicsThread.h>
 #include    <epicsString.h>
@@ -579,7 +580,12 @@ PM304Config(int card,           /* card being configured */
     motor_state[card]->DevicePrivate = malloc(sizeof(struct PM304controller));
     cntrl = (struct PM304controller *) motor_state[card]->DevicePrivate;
     cntrl->n_axes = n_axes;
-	cntrl->home_modes = home_modes;
+	for (int i=0; i<n_axes; i++) {
+		// Based on 32-bit integer, splitting across 8 axis. 4 bits -> 8 modes
+		int n_modes = 8;
+		cntrl->home_mode[i] = int(home_modes/float(pow(double(n_modes), i)))%n_modes;
+		printf("Homing axis %i using mode %i\n", i+1, cntrl->home_mode[i]);
+	}
     cntrl->model = MODEL_PM304;  /* Assume PM304 initially */
     strcpy(cntrl->port, port);
     return(OK);

--- a/motorApp/MclennanSrc/drvPM304.cc
+++ b/motorApp/MclennanSrc/drvPM304.cc
@@ -566,7 +566,8 @@ PM304Setup(int num_cards,       /* maximum number of controllers in system */
 RTN_STATUS
 PM304Config(int card,           /* card being configured */
             const char *port,   /* asyn port name */
-            int n_axes)         /* Number of axes */
+            int n_axes,         /* Number of axes */
+            int home_modes)     /* Combined home modes of all axes */
 {
     struct PM304controller *cntrl;
 
@@ -578,6 +579,7 @@ PM304Config(int card,           /* card being configured */
     motor_state[card]->DevicePrivate = malloc(sizeof(struct PM304controller));
     cntrl = (struct PM304controller *) motor_state[card]->DevicePrivate;
     cntrl->n_axes = n_axes;
+	cntrl->home_modes = home_modes;
     cntrl->model = MODEL_PM304;  /* Assume PM304 initially */
     strcpy(cntrl->port, port);
     return(OK);

--- a/motorApp/MclennanSrc/drvPM304.h
+++ b/motorApp/MclennanSrc/drvPM304.h
@@ -36,10 +36,11 @@ struct PM304controller
     int n_axes;             /* Number of axes on this controller */
     int model;              /* Model = MODEL_PM304 or MODEL_PM600 */
     int use_encoder[PM304_MAX_CHANNELS];  /* Does axis have an encoder? */
+	int home_modes; /* The combined home modes for all axes */
     char port[80];          /* asyn port name */
 };
 
 RTN_STATUS PM304Setup(int, int);
-RTN_STATUS PM304Config(int, const char *, int);
+RTN_STATUS PM304Config(int, const char *, int, int);
 
 #endif	/* INCdrvPM304h */

--- a/motorApp/MclennanSrc/drvPM304.h
+++ b/motorApp/MclennanSrc/drvPM304.h
@@ -36,7 +36,7 @@ struct PM304controller
     int n_axes;             /* Number of axes on this controller */
     int model;              /* Model = MODEL_PM304 or MODEL_PM600 */
     int use_encoder[PM304_MAX_CHANNELS];  /* Does axis have an encoder? */
-	int home_modes; /* The combined home modes for all axes */
+	int home_mode[PM304_MAX_CHANNELS]; /* The combined home modes for all axes */
     char port[80];          /* asyn port name */
 };
 

--- a/motorApp/MclennanSrc/homing.st
+++ b/motorApp/MclennanSrc/homing.st
@@ -1,10 +1,9 @@
-program homing("MOTPV=xxx,MODE")
+program homing("MOTPV=xxx,MODE,AXIS")
 
 #include "seqPVmacros.h"
 
 char* SNLtaskName;
 int jog_forward_value, jog_reverse_value;
-char* macros;
 assign jog_forward_value to "{MOTPV}.JOGF";
 assign jog_reverse_value to "{MOTPV}.JOGR";
 
@@ -15,6 +14,7 @@ assign position_d to "{MOTPV}.DVAL";
 
 int debug_flag;
 int mode;
+int axis;
 
 /* Turn on run-time debug messages */
 option +d;
@@ -32,7 +32,8 @@ ss motor
 	{
 	  /* 0: Use motor home, 1: Constant velocity move, 2: Reverse home and s position to 0 */
 	  mode = atoi(macValueGet("MODE"));
-	  printf("Homing sequence move mode set to %i\n", mode);
+	  axis = atoi(macValueGet("AXIS"));
+	  printf("Sequencer: Homing mode for axis %i set to %i\n", axis, mode);
 	} state ready
   }
 

--- a/motorApp/MclennanSrc/homing.st
+++ b/motorApp/MclennanSrc/homing.st
@@ -1,4 +1,4 @@
-program homing("MOTPV=xxx,MODE=Constant_velocity")
+program homing("MOTPV=xxx,MODE=0")
 
 #include "seqPVmacros.h"
 
@@ -23,8 +23,8 @@ ss motor
   {
 	when ()
 	{
-	  /* Currently we only have one mode so it isn't used. */
-	  mode = "{MODE}";
+	  /* 0: Use motor home, 1: Constant velocity move */
+	  mode = 1;
 	} state ready
   }
 
@@ -42,16 +42,20 @@ ss motor
   state forward_home_requested
   {
 	when (home_forward_pv==0) {
-	  jog_forward_value = 1;
-	  pvPut(jog_forward_value);
+	  if ( mode==1 ) {
+	    jog_forward_value = 1;
+	    pvPut(jog_forward_value);
+	  }
 	} state moving
   }
   
   state reverse_home_requested
   {
 	when (home_reverse_pv==0) {
-	  jog_reverse_value = 1;
-	  pvPut(jog_reverse_value);	  
+	  if ( mode==1 ) {
+	    jog_reverse_value = 1;
+	    pvPut(jog_reverse_value);
+	  }
 	} state moving
   }
 

--- a/motorApp/MclennanSrc/homing.st
+++ b/motorApp/MclennanSrc/homing.st
@@ -38,7 +38,7 @@ ss motor
   }
 
   state ready
-  {
+  {	
     when (home_reverse_pv==1)
     {
     } state reverse_home_requested
@@ -52,33 +52,25 @@ ss motor
   {
 	when (home_forward_pv==0) {
 	  if ( mode==1 ) {
-		/* Clear any outstanding jogs */
-	    jog_reverse_value = 0;
-	    pvPut(jog_reverse_value);
-	    jog_forward_value = 0;
-	    pvPut(jog_forward_value);
-		
-		/* New jog */
 	    jog_forward_value = 1;
 	    pvPut(jog_forward_value);
 	  }
-	} state moving
+	} state processing_jog_request
   }
   
   state reverse_home_requested
   {
 	when (home_reverse_pv==0) {
-	  if ( mode==1 ) {
-		/* Clear any outstanding jogs */
-	    jog_reverse_value = 0;
-	    pvPut(jog_reverse_value);
-	    jog_forward_value = 0;
-	    pvPut(jog_forward_value);
-		
-		/* New jog */
+	  if ( mode==1 ) {		
 	    jog_reverse_value = 1;
 	    pvPut(jog_reverse_value);
 	  }
+	} state processing_jog_request
+  }
+  
+  state processing_jog_request
+  {
+	when (movable==0) {
 	} state moving
   }
 
@@ -98,6 +90,15 @@ ss motor
 		set = 0;
 		pvPut(set);
 	  }
-    } state ready
+    } state done
   }
+  
+  state done {
+    when () {
+	  jog_reverse_value = 0;
+	  pvPut(jog_reverse_value);
+	  jog_forward_value = 0;
+	  pvPut(jog_forward_value);
+	} state ready
+  } 
 }

--- a/motorApp/MclennanSrc/homing.st
+++ b/motorApp/MclennanSrc/homing.st
@@ -52,6 +52,13 @@ ss motor
   {
 	when (home_forward_pv==0) {
 	  if ( mode==1 ) {
+		/* Clear any outstanding jogs */
+	    jog_reverse_value = 0;
+	    pvPut(jog_reverse_value);
+	    jog_forward_value = 0;
+	    pvPut(jog_forward_value);
+		
+		/* New jog */
 	    jog_forward_value = 1;
 	    pvPut(jog_forward_value);
 	  }
@@ -62,6 +69,13 @@ ss motor
   {
 	when (home_reverse_pv==0) {
 	  if ( mode==1 ) {
+		/* Clear any outstanding jogs */
+	    jog_reverse_value = 0;
+	    pvPut(jog_reverse_value);
+	    jog_forward_value = 0;
+	    pvPut(jog_forward_value);
+		
+		/* New jog */
 	    jog_reverse_value = 1;
 	    pvPut(jog_reverse_value);
 	  }

--- a/motorApp/MclennanSrc/homing.st
+++ b/motorApp/MclennanSrc/homing.st
@@ -30,8 +30,9 @@ ss motor
   {
 	when ()
 	{
-	  /* "0": Use motor home, "1": Constant velocity move */
+	  /* 0: Use motor home, 1: Constant velocity move, 2: Reverse home and s position to 0 */
 	  mode = atoi(macValueGet("MODE"));
+	  printf("Homing sequence move mode set to %i\n", mode);
 	} state ready
   }
 
@@ -70,7 +71,7 @@ ss motor
   {	
     when (movable==1)
     { 
-	  if ( mode==0 ) {
+	  if ( mode==2 ) {
 		set = 1;
 		position = 0;
 		position_d = 0;

--- a/motorApp/MclennanSrc/homing.st
+++ b/motorApp/MclennanSrc/homing.st
@@ -1,13 +1,20 @@
-program homing("MOTPV=xxx,MODE=0")
+program homing("MOTPV=xxx,MODE")
 
 #include "seqPVmacros.h"
 
 char* SNLtaskName;
-char* mode;
 int jog_forward_value, jog_reverse_value;
+char* macros;
 assign jog_forward_value to "{MOTPV}.JOGF";
 assign jog_reverse_value to "{MOTPV}.JOGR";
+
+int set, position, position_d;
+assign set to "{MOTPV}.SET";
+assign position to "{MOTPV}.VAL";
+assign position_d to "{MOTPV}.DVAL";
+
 int debug_flag;
+int mode;
 
 /* Turn on run-time debug messages */
 option +d;
@@ -23,8 +30,8 @@ ss motor
   {
 	when ()
 	{
-	  /* 0: Use motor home, 1: Constant velocity move */
-	  mode = 1;
+	  /* "0": Use motor home, "1": Constant velocity move */
+	  mode = atoi(macValueGet("MODE"));
 	} state ready
   }
 
@@ -63,6 +70,18 @@ ss motor
   {	
     when (movable==1)
     { 
+	  if ( mode==0 ) {
+		set = 1;
+		position = 0;
+		position_d = 0;
+		
+		pvPut(set);
+		pvPut(position);
+		pvPut(position_d);
+		
+		set = 0;
+		pvPut(set);
+	  }
     } state ready
   }
 }


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/2021

The JOG PVs are toggles, unlike the homing PVs which clear once the operation is complete. If the jog PV isn't cleared at the end of the operation then it is left on and can interfere with subsequent operations.

To test:
- Set up a McLennan motor
- Home (which is secretly a jog)
- Check that upon completion the jog PVs are 0

Further, check the ticket workflow works:

- Set up a motor
- Set the lower limit above the current position
- Reverse home
- Forward home

Previously the last step wouldn't work. Now it should.
