### PR TITLE
Don't wait for homing cancellation if mode not 1. Add some debug output

### DIFF
--- a/motorApp/MclennanSrc/homing.st
+++ b/motorApp/MclennanSrc/homing.st
@@ -1,4 +1,4 @@
-program homing("MOTPV=xxx,MODE,AXIS")
+program homing("MOTPV=xxx,MODE,AXIS,DEBUG")
 
 #include "seqPVmacros.h"
 
@@ -13,6 +13,7 @@ assign position to "{MOTPV}.VAL";
 assign position_d to "{MOTPV}.DVAL";
 
 int debug_flag;
+int debug;
 int mode;
 int axis;
 
@@ -33,6 +34,7 @@ ss motor
 	  /* 0: Use motor home, 1: Constant velocity move, 2: Reverse home and s position to 0 */
 	  mode = atoi(macValueGet("MODE"));
 	  axis = atoi(macValueGet("AXIS"));
+	  axis = atoi(macValueGet("DEBUG"));
 	  printf("Sequencer: Homing mode for axis %i set to %i\n", axis, mode);
 	} state ready
   }
@@ -41,36 +43,63 @@ ss motor
   {	
     when (home_reverse_pv==1)
     {
+	  if (debug) {
+	    printf("Sequencer: FROM ready TO reverse_home_requested\n");
+	  }
     } state reverse_home_requested
 	
     when (home_forward_pv==1)
     {
+	  if (debug) {
+	    printf("Sequencer: FROM ready TO forward_home_requested\n");
+	  }
     } state forward_home_requested
   }
   
   state forward_home_requested
   {
-	when (home_forward_pv==0) {
-	  if ( mode==1 ) {
-	    jog_forward_value = 1;
-	    pvPut(jog_forward_value);
+    /* In mode 1 we need to wait for the home to be cancelled before requesting a jog */
+	when (home_forward_pv==0 && mode==1) {
+	  jog_forward_value = 1;
+	  pvPut(jog_forward_value);
+	  if (debug) {
+	    printf("Sequencer: FROM forward_home_requested TO processing_move_request (mode 1)\n");
 	  }
-	} state processing_jog_request
+	} state processing_move_request
+	
+    /* No delay needed for modes other than 1 */
+	when (mode!=1) {
+	  if (debug) {
+	    printf("Sequencer: FROM forward_home_requested TO processing_move_request\n");
+	  }
+	} state processing_move_request
   }
   
   state reverse_home_requested
   {
-	when (home_reverse_pv==0) {
-	  if ( mode==1 ) {		
-	    jog_reverse_value = 1;
-	    pvPut(jog_reverse_value);
+    /* In mode 1 we need to wait for the home to be cancelled before requesting a jog */
+	when (mode==1 && home_reverse_pv==0) {
+	  jog_reverse_value = 1;
+	  pvPut(jog_reverse_value);
+	  if (debug) {
+	    printf("Sequencer: FROM reverse_home_requested TO processing_move_request (mode 1)\n");
 	  }
-	} state processing_jog_request
+	} state processing_move_request
+	
+    /* No delay needed for modes other than 1 */
+	when (mode!=1) {
+	  if (debug) {
+	    printf("Sequencer: FROM reverse_home_requested TO processing_move_request\n");
+	  }
+	} state processing_move_request
   }
   
-  state processing_jog_request
+  state processing_move_request
   {
 	when (movable==0) {
+	  if (debug) {
+	    printf("Sequencer: FROM processing_move_request TO moving\n");
+	  }
 	} state moving
   }
 
@@ -90,15 +119,23 @@ ss motor
 		set = 0;
 		pvPut(set);
 	  }
+	  if (debug) {
+	    printf("Sequencer: FROM moving TO done\n");
+	  }
     } state done
   }
   
   state done {
     when () {
-	  jog_reverse_value = 0;
-	  pvPut(jog_reverse_value);
-	  jog_forward_value = 0;
-	  pvPut(jog_forward_value);
+	  if ( mode==1 ) {
+	    jog_reverse_value = 0;
+	    pvPut(jog_reverse_value);
+	    jog_forward_value = 0;
+	    pvPut(jog_forward_value);
+	  }
+	  if (debug) {
+	    printf("Sequencer: FROM done TO ready\n");
+	  }
 	} state ready
   } 
 }

--- a/motorApp/MclennanSrc/homing.st
+++ b/motorApp/MclennanSrc/homing.st
@@ -34,8 +34,11 @@ ss motor
 	  /* 0: Use motor home, 1: Constant velocity move, 2: Reverse home and s position to 0 */
 	  mode = atoi(macValueGet("MODE"));
 	  axis = atoi(macValueGet("AXIS"));
-	  axis = atoi(macValueGet("DEBUG"));
+	  debug = atoi(macValueGet("DEBUG"));
 	  printf("Sequencer: Homing mode for axis %i set to %i\n", axis, mode);
+	  if (debug) {
+		printf("Sequencer: Debug mode ON");
+	  }
 	} state ready
   }
 


### PR DESCRIPTION
### Description of work

Vesuvio reported than homing mode 2 for McLennans wasn't working as expected. On inspection of the code, several actions were being taken that were exclusive to mode 1. This has now been fixed. I've also added some debug output so looking at the console you can see what the sequencer is doing.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2289

### Acceptance criteria

When "DEBUG" is set to 1, the console output for the motor shows the state transitions in the sequencer. Try moving the motor to home to see some transitions

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final steps

- [x] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
