### PR TITLE
Ticket2785: Archive MISS and RCNT motor fields

### DIFF
--- a/motorApp/Db/asyn_motor.db
+++ b/motorApp/Db/asyn_motor.db
@@ -23,6 +23,9 @@ record(motor, "$(P)$(M)") {
   field(RTRY, "$(RTRY=10)")
   field(TWV, "1")
   field(SDIS, "$(P)$(M)_able.VAL")
+  # ISIS local archiving and alarm
+  info(archive, "0.02 VAL RBV DVAL OFF MSTA DIR CNEN MOVN DMOV MISS RCNT")
+  info(alarm, "Motors")
 }
 
 # ISIS local aliases for genie_python

--- a/motorApp/Db/basic_asyn_motor.db
+++ b/motorApp/Db/basic_asyn_motor.db
@@ -17,6 +17,9 @@ record(motor,"$(P)$(M)")
 	field(DLLM,"$(DLLM)")
 	field(INIT,"$(INIT)")
 	field(TWV,"1")
+	# ISIS local archiving and alarm
+	info(archive, "0.02 VAL RBV DVAL OFF MSTA DIR CNEN MOVN DMOV MISS RCNT")
+	info(alarm, "Motors")
 }
 
 # ISIS local aliases for genie_python

--- a/motorApp/Db/basic_motor.db
+++ b/motorApp/Db/basic_motor.db
@@ -17,6 +17,9 @@ grecord(motor,"$(P)$(M)")
 	field(DLLM,"$(DLLM)")
 	field(INIT,"$(INIT)")
 	field(TWV,"1")
+	# ISIS local archiving and alarm
+	info(archive, "0.02 VAL RBV DVAL OFF MSTA DIR CNEN MOVN DMOV MISS RCNT")
+	info(alarm, "Motors")
 }
 
 # ISIS local aliases for genie_python

--- a/motorApp/Db/motor.db
+++ b/motorApp/Db/motor.db
@@ -24,6 +24,9 @@ record(motor, "$(P)$(M)") {
   field(INIT, "$(INIT)")
   field(TWV, "1")
   field(SDIS, "$(P)$(M)_able.VAL")
+  # ISIS local archiving and alarm
+  info(archive, "0.02 VAL RBV DVAL OFF MSTA DIR CNEN MOVN DMOV MISS RCNT")
+  info(alarm, "Motors")
 }
 
 # ISIS local aliases for genie_python


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/2785

To test:
* Rebuild this module
* Rebuild a motor module, for example LINMOT (not GALIL)
* Start your instrument
* Start one of the rebuilt motors in devsim
* Go to http://localhost:4812/group?name=INST and confirm that the MISS and RCNT fields of the started motor are there