### PR TITLE
Send the reset command after every move. Configurable at startup

### DIFF
--- a/motorApp/MclennanSrc/MclennanRegister.cc
+++ b/motorApp/MclennanSrc/MclennanRegister.cc
@@ -34,13 +34,14 @@ static const iocshArg configArg0 = {"Card being configured", iocshArgInt};
 static const iocshArg configArg1 = {"asyn port name", iocshArgString};
 static const iocshArg configArg2 = {"Number of axes", iocshArgInt};
 static const iocshArg configArg3 = {"Combined home modes for all axes", iocshArgInt};
+static const iocshArg configArg4 = {"Reset before move", iocshArgInt};
 
 static const iocshArg * const PM304SetupArgs[2]  = {&setupArg0, &setupArg1};
-static const iocshArg * const PM304ConfigArgs[4] = {&configArg0, &configArg1,
-    &configArg2, &configArg3};
+static const iocshArg * const PM304ConfigArgs[5] = {&configArg0, &configArg1,
+    &configArg2, &configArg3, &configArg4};
 
 static const iocshFuncDef setupPM304  = {"PM304Setup",  2, PM304SetupArgs};
-static const iocshFuncDef configPM304 = {"PM304Config", 4, PM304ConfigArgs};
+static const iocshFuncDef configPM304 = {"PM304Config", 5, PM304ConfigArgs};
 
 static void setupPM304CallFunc(const iocshArgBuf *args)
 {
@@ -48,7 +49,7 @@ static void setupPM304CallFunc(const iocshArgBuf *args)
 }
 static void configPM304CallFunc(const iocshArgBuf *args)
 {
-    PM304Config(args[0].ival, args[1].sval, args[2].ival, args[3].ival);
+    PM304Config(args[0].ival, args[1].sval, args[2].ival, args[3].ival, args[4].ival);
 }
 
 static void MclennanRegister(void)

--- a/motorApp/MclennanSrc/devPM304.cc
+++ b/motorApp/MclennanSrc/devPM304.cc
@@ -232,7 +232,10 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
             if (strlen(mr->post) != 0)
                 motor_call->postmsgptr = (char *) &mr->post;
             break;
-
+	        /* Send a reset command before any move */
+			if (cntrl->reset_before_move==1) {
+				sprintf(buff, "%dRS;", axis);
+			}
         default:
             break;
     }

--- a/motorApp/MclennanSrc/devPM304.cc
+++ b/motorApp/MclennanSrc/devPM304.cc
@@ -231,12 +231,12 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
             }
             if (strlen(mr->post) != 0)
                 motor_call->postmsgptr = (char *) &mr->post;
+	        /* Send a reset command before any move */
 			if (cntrl->reset_before_move==1) {
 				sprintf(buff, "%dRS;", axis);
                 strcat(motor_call->message, buff);
 			}
             break;
-	        /* Send a reset command before any move */
         default:
             break;
     }

--- a/motorApp/MclennanSrc/devPM304.cc
+++ b/motorApp/MclennanSrc/devPM304.cc
@@ -231,11 +231,12 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
             }
             if (strlen(mr->post) != 0)
                 motor_call->postmsgptr = (char *) &mr->post;
-            break;
-	        /* Send a reset command before any move */
 			if (cntrl->reset_before_move==1) {
 				sprintf(buff, "%dRS;", axis);
+                strcat(motor_call->message, buff);
 			}
+            break;
+	        /* Send a reset command before any move */
         default:
             break;
     }

--- a/motorApp/MclennanSrc/drvPM304.cc
+++ b/motorApp/MclennanSrc/drvPM304.cc
@@ -565,10 +565,11 @@ PM304Setup(int num_cards,       /* maximum number of controllers in system */
 /* PM304Config()                                    */
 /*****************************************************/
 RTN_STATUS
-PM304Config(int card,           /* card being configured */
-            const char *port,   /* asyn port name */
-            int n_axes,         /* Number of axes */
-            int home_modes)     /* Combined home modes of all axes */
+PM304Config(int card,             /* card being configured */
+            const char *port,     /* asyn port name */
+            int n_axes,           /* Number of axes */
+            int home_modes,       /* Combined home modes of all axes */
+			int reset_before_move) /* Reset the McLennan before every move */
 {
     struct PM304controller *cntrl;
 
@@ -586,6 +587,7 @@ PM304Config(int card,           /* card being configured */
 		cntrl->home_mode[i] = int(home_modes/float(pow(double(n_modes), i)))%n_modes;
 		printf("Homing axis %i using mode %i\n", i+1, cntrl->home_mode[i]);
 	}
+	cntrl->reset_before_move = reset_before_move;
     cntrl->model = MODEL_PM304;  /* Assume PM304 initially */
     strcpy(cntrl->port, port);
     return(OK);

--- a/motorApp/MclennanSrc/drvPM304.h
+++ b/motorApp/MclennanSrc/drvPM304.h
@@ -37,10 +37,11 @@ struct PM304controller
     int model;              /* Model = MODEL_PM304 or MODEL_PM600 */
     int use_encoder[PM304_MAX_CHANNELS];  /* Does axis have an encoder? */
 	int home_mode[PM304_MAX_CHANNELS]; /* The combined home modes for all axes */
-    char port[80];          /* asyn port name */
+    char port[80];          /* Asyn port name */
+	int reset_before_move;  /* Reset the controller before any move command */
 };
 
 RTN_STATUS PM304Setup(int, int);
-RTN_STATUS PM304Config(int, const char *, int, int);
+RTN_STATUS PM304Config(int, const char *, int, int, int);
 
 #endif	/* INCdrvPM304h */


### PR DESCRIPTION
I've added an extra argument to PM304Config so that, when set, a reset command is sent on every move. Otherwise it is not.

https://github.com/ISISComputingGroup/IBEX/issues/2760

Acceptance tests:

https://github.com/ISISComputingGroup/EPICS-ioc/pull/208