### PR TITLE
Ticket2760 send mc lennan reset on move

### DIFF
--- a/motorApp/MclennanSrc/devPM304.cc
+++ b/motorApp/MclennanSrc/devPM304.cc
@@ -289,6 +289,10 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
            of all motors */
         break;
     case STOP_AXIS:
+	    /* Send a reset before the stop command so that it's not impeded by a tracking abort */
+		sprintf(buff, "%dRS;", axis);
+        strcat(motor_call->message, buff);
+		
         sprintf(buff, "%dST;", axis);
         break;
     case JOG:

--- a/motorApp/MclennanSrc/devPM304.cc
+++ b/motorApp/MclennanSrc/devPM304.cc
@@ -231,9 +231,9 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
             }
             if (strlen(mr->post) != 0)
                 motor_call->postmsgptr = (char *) &mr->post;
-	        /* Send a reset command before any move */
-			if (cntrl->reset_before_move==1) {
-				sprintf(buff, "%dRS;", axis);
+            /* Send a reset command before any move */
+            if (cntrl->reset_before_move==1) {
+                sprintf(buff, "%dRS;", axis);
                 strcat(motor_call->message, buff);
 			}
             break;
@@ -289,8 +289,8 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
            of all motors */
         break;
     case STOP_AXIS:
-	    /* Send a reset before the stop command so that it's not impeded by a tracking abort */
-		sprintf(buff, "%dRS;", axis);
+        /* Send a reset before the stop command so that it's not impeded by a tracking abort */
+        sprintf(buff, "%dRS;", axis);
         strcat(motor_call->message, buff);
 		
         sprintf(buff, "%dST;", axis);

--- a/motorApp/MclennanSrc/drvPM304.cc
+++ b/motorApp/MclennanSrc/drvPM304.cc
@@ -375,13 +375,17 @@ STATIC RTN_STATUS send_mess(int card, const char *com, char *name)
      * characters.  The PM304 cannot handle more than 1 command on a line
      * so send them separately */
     strcpy(temp, com);
-    for (p = epicsStrtok_r(temp, ";", &tok_save);
+    for (p = epicsStrtok_r(temp, ";", &tok_save);		 
                 ((p != NULL) && (strlen(p) != 0));
                 p = epicsStrtok_r(NULL, ";", &tok_save)) {
+		
         Debug(2, "send_mess: sending message to card %d, message=%s\n", card, p);
-    pasynOctetSyncIO->writeRead(cntrl->pasynUser, p, strlen(p), response,
+	    pasynOctetSyncIO->writeRead(cntrl->pasynUser, p, strlen(p), response,
                 BUFF_SIZE, TIMEOUT, &nwrite, &nread, &eomReason);
-        Debug(2, "send_mess: card %d, response=%s\n", card, response);
+		/* Set the debug level for most responses to be 2. Flag reset messages
+		 * to 1 so we can spot them more easily */
+		int level = strcmp(&p[1],"RS")==0 && strstr(response, "NOT ABORTED") == NULL ? 1 : 2;
+        Debug(level, "send_mess: card %d, response=...\n%s\n", card, response);
     }
 
     return(OK);


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/EPICS-ioc/pull/213

I've made it so that successful resets have a higher priority than other kinds of message to allow easier filtering in the IOC logs.

When the device receives a reset command that has to be actioned, it triggers an alarm state.