### PR TITLE
Add homing mode for CV move and zero

### DIFF
--- a/motorApp/MclennanSrc/devPM304.cc
+++ b/motorApp/MclennanSrc/devPM304.cc
@@ -289,10 +289,12 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
            of all motors */
         break;
     case STOP_AXIS:
-        /* Send a reset before the stop command so that it's not impeded by a tracking abort */
+	    /* Send a stop command as our first port of call */
+        sprintf(buff, "%dST;", axis);
+        strcat(motor_call->message, buff);
+        /* Send a second stop preceded by a reset command as a contingency in case the first stop is impeded by a tracking abort */
         sprintf(buff, "%dRS;", axis);
         strcat(motor_call->message, buff);
-		
         sprintf(buff, "%dST;", axis);
         break;
     case JOG:

--- a/motorApp/MclennanSrc/homing.st
+++ b/motorApp/MclennanSrc/homing.st
@@ -29,116 +29,119 @@ ss motor
 {
   state init
   {
-	when ()
-	{
-	  /* 0: Use motor home, 1: Constant velocity move, 2: Reverse home and s position to 0 */
-	  mode = atoi(macValueGet("MODE"));
-	  axis = atoi(macValueGet("AXIS"));
-	  debug = atoi(macValueGet("DEBUG"));
-	  printf("Sequencer: Homing mode for axis %i set to %i\n", axis, mode);
-	  if (debug) {
-		printf("Sequencer: Debug mode ON");
-	  }
-	} state ready
+    when ()
+    {
+      /* 0: Use motor home, 1: Constant velocity move, 2: Reverse home and s position to 0, 3: Constant veloctiy move and 0 */
+      mode = atoi(macValueGet("MODE"));
+      axis = atoi(macValueGet("AXIS"));
+      debug = atoi(macValueGet("DEBUG"));
+      printf("Sequencer: Homing mode for axis %i set to %i\n", axis, mode);
+      if (debug) {
+        printf("Sequencer: Debug mode ON");
+      }
+    } state ready
   }
 
   state ready
-  {	
+  { 
     when (home_reverse_pv==1)
     {
-	  if (debug) {
-	    printf("Sequencer: FROM ready TO reverse_home_requested\n");
-	  }
+      if (debug) {
+        printf("Sequencer: FROM ready TO reverse_home_requested\n");
+      }
     } state reverse_home_requested
-	
+    
     when (home_forward_pv==1)
     {
-	  if (debug) {
-	    printf("Sequencer: FROM ready TO forward_home_requested\n");
-	  }
+      if (debug) {
+        printf("Sequencer: FROM ready TO forward_home_requested\n");
+      }
     } state forward_home_requested
   }
   
   state forward_home_requested
   {
-    /* In mode 1 we need to wait for the home to be cancelled before requesting a jog */
-	when (home_forward_pv==0 && mode==1) {
-	  jog_forward_value = 1;
-	  pvPut(jog_forward_value);
-	  if (debug) {
-	    printf("Sequencer: FROM forward_home_requested TO processing_move_request (mode 1)\n");
-	  }
-	} state processing_move_request
-	
+    /* In modes 1 and 3 we need to wait for the home to be cancelled before requesting a jog */
+    when (home_forward_pv==0 && (mode==1 || mode==3)) {
+      jog_forward_value = 1;
+      pvPut(jog_forward_value);
+      if (debug) {
+        printf("Sequencer: FROM forward_home_requested TO processing_move_request (constant velocity move)\n");
+      }
+    } state processing_move_request
+    
     /* No delay needed for modes other than 1 */
-	when (mode!=1) {
-	  if (debug) {
-	    printf("Sequencer: FROM forward_home_requested TO processing_move_request\n");
-	  }
-	} state processing_move_request
+    when (!(mode==1 || mode==3)) {
+      if (debug) {
+        printf("Sequencer: FROM forward_home_requested TO processing_move_request\n");
+      }
+    } state processing_move_request
   }
   
   state reverse_home_requested
   {
-    /* In mode 1 we need to wait for the home to be cancelled before requesting a jog */
-	when (mode==1 && home_reverse_pv==0) {
-	  jog_reverse_value = 1;
-	  pvPut(jog_reverse_value);
-	  if (debug) {
-	    printf("Sequencer: FROM reverse_home_requested TO processing_move_request (mode 1)\n");
-	  }
-	} state processing_move_request
-	
-    /* No delay needed for modes other than 1 */
-	when (mode!=1) {
-	  if (debug) {
-	    printf("Sequencer: FROM reverse_home_requested TO processing_move_request\n");
-	  }
-	} state processing_move_request
+    /* In modes 1 and 3 we need to wait for the home to be cancelled before requesting a jog */
+    when ((mode==1 || mode==3) && home_reverse_pv==0) {
+      jog_reverse_value = 1;
+      pvPut(jog_reverse_value);
+      if (debug) {
+        printf("Sequencer: FROM reverse_home_requested TO processing_move_request (constant velocity move)\n");
+      }
+    } state processing_move_request
+    
+    /* No delay needed for modes other than 1 and 3 */
+    when (!(mode==1 || mode==3)) {
+      if (debug) {
+        printf("Sequencer: FROM reverse_home_requested TO processing_move_request\n");
+      }
+    } state processing_move_request
   }
   
   state processing_move_request
   {
-	when (movable==0) {
-	  if (debug) {
-	    printf("Sequencer: FROM processing_move_request TO moving\n");
-	  }
-	} state moving
+    when (movable==0) {
+      if (debug) {
+        printf("Sequencer: FROM processing_move_request TO moving\n");
+      }
+    } state moving
   }
 
   state moving
-  {	
+  { 
     when (movable==1)
     { 
-	  if ( mode==2 ) {
-		set = 1;
-		position = 0;
-		position_d = 0;
-		
-		pvPut(set);
-		pvPut(position);
-		pvPut(position_d);
-		
-		set = 0;
-		pvPut(set);
-	  }
-	  if (debug) {
-	    printf("Sequencer: FROM moving TO done\n");
-	  }
+      if ( mode==2 || mode==3 ) {
+        if (debug) {
+            printf("Sequencer: Setting position to zero (modes 2 and 3)\n");
+        }
+        set = 1;
+        position = 0;
+        position_d = 0;
+        
+        pvPut(set);
+        pvPut(position);
+        pvPut(position_d);
+        
+        set = 0;
+        pvPut(set);
+      }
+      if (debug) {
+        printf("Sequencer: FROM moving TO done\n");
+      }
     } state done
   }
   
   state done {
     when () {
-	  if ( mode==1 ) {
-	    jog_reverse_value = 0;
-	    pvPut(jog_reverse_value);
-	    jog_forward_value = 0;
-	    pvPut(jog_forward_value);
-	  }
-	  if (debug) {
-	    printf("Sequencer: FROM done TO ready\n");
-	  }
-	} state ready
+      if ( (mode==1 || mode==3) ) {
+        jog_reverse_value = 0;
+        pvPut(jog_reverse_value);
+        jog_forward_value = 0;
+        pvPut(jog_forward_value);
+      }
+      if (debug) {
+        printf("Sequencer: FROM done TO ready\n");
+      }
+    } state ready
   } 
 }

--- a/motorApp/MclennanSrc/homing.st
+++ b/motorApp/MclennanSrc/homing.st
@@ -110,7 +110,7 @@ ss motor
   { 
     when (movable==1)
     { 
-      if ( mode==2 || mode==3 ) {
+      if (mode==2 || mode==3) {
         if (debug) {
             printf("Sequencer: Setting position to zero (modes 2 and 3)\n");
         }

--- a/motorApp/MclennanSrc/homing.st
+++ b/motorApp/MclennanSrc/homing.st
@@ -133,7 +133,7 @@ ss motor
   
   state done {
     when () {
-      if ( (mode==1 || mode==3) ) {
+      if (mode==1 || mode==3) {
         jog_reverse_value = 0;
         pvPut(jog_reverse_value);
         jog_forward_value = 0;


### PR DESCRIPTION
### Description of work

I've added a new homing mode for McLennan motors: constant velocity move and zero.

**Also contains https://github.com/ISISComputingGroup/EPICS-motor/pull/27. Review that first**

### To test

https://github.com/ISISComputingGroup/IBEX/issues/3077

### Acceptance criteria

- Other homing modes unaffected
    - Notably mode 1 is the one most likely to be affected and the only one we can test with the office McLennan
    - Mode 1 should do a jog to the limit. When it gets there the position should not be reset
- There is a new homing mode, identical to mode 1 but which zeroes the position when it reaches its destination,
    - Do a home
    - When the motor reaches the limit, the position should be zeroed
    - Other actions shouldn't cause the position to be zeroed (e.g. a jog)
    - If you ask for the motor to home and then stop it, it may still zero. This is a known issue that we've decided not to action.