### PR TITLE
Stop-reset-stop to cover stop under normal mode and tracking abort

### DIFF
--- a/motorApp/MclennanSrc/devPM304.cc
+++ b/motorApp/MclennanSrc/devPM304.cc
@@ -289,10 +289,12 @@ STATIC RTN_STATUS PM304_build_trans(motor_cmnd command, double *parms, struct mo
            of all motors */
         break;
     case STOP_AXIS:
-        /* Send a reset before the stop command so that it's not impeded by a tracking abort */
+	    /* Send a stop command as our first port of call */
+        sprintf(buff, "%dST;", axis);
+        strcat(motor_call->message, buff);
+        /* Send a second stop preceded by a reset command as a contingency in case the first stop is impeded by a tracking abort */
         sprintf(buff, "%dRS;", axis);
         strcat(motor_call->message, buff);
-		
         sprintf(buff, "%dST;", axis);
         break;
     case JOG:


### PR DESCRIPTION
Description:
The stop command has gone through the following iterations:
    - STOP: Original command just sent stop, but it didn't stop the motor if it had gone into an error state
    - RESET-STOP: Reset any error before trying to stop. Stops motor if it has entered a tracking abort state but apparently doesn't stop the motor if it is in a normal state
    - STOP-RESET-STOP: Stops the McLennan coming from either state

Ticket:
https://github.com/ISISComputingGroup/IBEX/issues/3192

Acceptance criteria:
- [x] Try moving the McLennan under normal operation (move, jog, home (mode 1 only)) and click stop. The motor should stop. The "Stop all" button should also have the same effect
- [x] Set the motor resolution to something incorrect (e.g. `-1/1`). Move the motor. When it enters a tracking abort state it will stop itself.