### PR TITLE
Ticket4908 mclennan homing

### DIFF
--- a/motorApp/MclennanSrc/homing.st
+++ b/motorApp/MclennanSrc/homing.st
@@ -4,6 +4,7 @@ program homing("MOTPV=xxx,MODE,AXIS,DEBUG")
 
 %% #include "string.h"
 %% #include "errlog.h"
+%% #include "float.h"
 
 char* SNLtaskName;
 int jog_forward_value, jog_reverse_value;
@@ -24,8 +25,8 @@ int debug;
 int mode;
 int axis;
 
-double cached_soft_high_limit = 0.0;
-double cached_soft_low_limit = 0.0;
+double cached_soft_high_limit;
+double cached_soft_low_limit;
 
 /* Turn on run-time debug messages */
 option +d;
@@ -69,7 +70,7 @@ ss motor
     when (home_reverse_pv==1)
     {
       if (debug) {
-        errlogSevPrintf(errlogInfo, "Sequencer: FROM ready TO reverse_home_requested\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: axis %i: FROM ready TO reverse_home_requested\n", axis);
       }
     } state reverse_home_requested
     
@@ -77,14 +78,14 @@ ss motor
     when ((home_forward_pv==1) && (mode==3))
     {
       if (debug) {
-        errlogSevPrintf(errlogInfo, "Sequencer: FROM ready TO reverse_home_requested\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: axis %i: FROM ready TO reverse_home_requested\n", axis);
       }
     } state reverse_home_requested
     
     when ((home_forward_pv==1) && (mode!=3))
     {
       if (debug) {
-        errlogSevPrintf(errlogInfo, "Sequencer: FROM ready TO forward_home_requested\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: axis %i: FROM ready TO forward_home_requested\n", axis);
       }
     } state forward_home_requested
     
@@ -93,8 +94,11 @@ ss motor
       cached_soft_high_limit = hlm;
       cached_soft_low_limit = llm;
       
-      PVPUT(hlm, 999999999);
-      PVPUT(llm, -999999999);
+      if (debug) {
+          errlogSevPrintf(errlogInfo, "Sequencer: axis %i: Caching limits (high=%f, low=%f)\n", axis, cached_soft_high_limit, cached_soft_low_limit);
+      }
+      PVPUT(hlm, DBL_MAX);
+      PVPUT(llm, -DBL_MAX);
     }
   }
   
@@ -106,14 +110,14 @@ ss motor
       jog_forward_value = 1;
       pvPut(jog_forward_value);
       if (debug) {
-        errlogSevPrintf(errlogInfo, "Sequencer: FROM forward_home_requested TO processing_move_request (constant velocity move)\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: axis %i: FROM forward_home_requested TO processing_move_request (constant velocity move)\n", axis);
       }
     } state processing_move_request
     
     /* No delay needed for modes other than 1 */
     when (!(mode==1 || mode==3)) {
       if (debug) {
-        errlogSevPrintf(errlogInfo, "Sequencer: FROM forward_home_requested TO processing_move_request\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: axis %i: FROM forward_home_requested TO processing_move_request\n", axis);
       }
     } state processing_move_request
   }
@@ -126,14 +130,14 @@ ss motor
       jog_reverse_value = 1;
       pvPut(jog_reverse_value);
       if (debug) {
-        errlogSevPrintf(errlogInfo, "Sequencer: FROM reverse_home_requested TO processing_move_request (constant velocity move)\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: axis %i: FROM reverse_home_requested TO processing_move_request (constant velocity move)\n", axis);
       }
     } state processing_move_request
     
     /* No delay needed for modes other than 1 and 3 */
     when (!(mode==1 || mode==3)) {
       if (debug) {
-        errlogSevPrintf(errlogInfo, "Sequencer: FROM reverse_home_requested TO processing_move_request\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: axis %i: FROM reverse_home_requested TO processing_move_request\n", axis);
       }
     } state processing_move_request
   }
@@ -142,9 +146,15 @@ ss motor
   {
     when (movable==0) {
       if (debug) {
-        errlogSevPrintf(errlogInfo, "Sequencer: FROM processing_move_request TO moving\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: axis %i: FROM processing_move_request TO moving\n", axis);
       }
     } state moving
+    
+    /* If move doesn't start within 10 seconds, cancel home (we may be in a state where we can't move) */
+    when(delay(10)){
+      errlogSevPrintf(errlogMajor, "Sequencer: axis %i: Unable to start homing move. Cancelling home.\n", axis);
+      errlogSevPrintf(errlogInfo, "Sequencer: axis %i: FROM processing_move_request TO done\n", axis);
+    } state done
   }
 
   state moving
@@ -153,7 +163,7 @@ ss motor
     { 
       if (mode==2 || mode==3) {
         if (debug) {
-            errlogSevPrintf(errlogInfo, "Sequencer: Setting position to zero (modes 2 and 3)\n");
+            errlogSevPrintf(errlogInfo, "Sequencer: axis %i: Setting position to zero (modes 2 and 3)\n", axis);
         }
 
         pvGet(offset);
@@ -170,7 +180,7 @@ ss motor
         PVPUT(set, 0);
       }
       if (debug) {
-        errlogSevPrintf(errlogInfo, "Sequencer: FROM moving TO done\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: axis %i: FROM moving TO done\n", axis);
       }
     } state done
   }
@@ -184,12 +194,15 @@ ss motor
         pvPut(jog_forward_value);
       }
       
+      if (debug) {
+          errlogSevPrintf(errlogInfo, "Sequencer: axis %i: Reapplying cached limits (high=%f, low=%f)\n", axis, cached_soft_high_limit, cached_soft_low_limit);
+      }
       /* Re-apply cached soft limits */
       PVPUT(hlm, cached_soft_high_limit);
       PVPUT(llm, cached_soft_low_limit);
       
       if (debug) {
-        errlogSevPrintf(errlogInfo, "Sequencer: FROM done TO ready\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: axis %i: FROM done TO ready\n", axis);
       }
     } state ready
   } 

--- a/motorApp/MclennanSrc/homing.st
+++ b/motorApp/MclennanSrc/homing.st
@@ -38,6 +38,10 @@ option +r;
 PV(int, home_forward_pv, "{MOTPV}.HOMF", Monitor);
 PV(int, home_reverse_pv, "{MOTPV}.HOMR", Monitor);
 PV(int, movable, "{MOTPV}.DMOV", Monitor);
+PV(int, user_stop, "{MOTPV}.STOP", Monitor);
+
+/* Need to use SNL queue synchronization to get all events here. */
+syncq user_stop 100;
 
 // Soft limits
 PV(double, hlm, "{MOTPV}.HLM", Monitor);
@@ -129,6 +133,7 @@ ss motor
     
       jog_reverse_value = 1;
       pvPut(jog_reverse_value);
+      
       if (debug) {
         errlogSevPrintf(errlogInfo, "Sequencer: axis %i: FROM reverse_home_requested TO processing_move_request (constant velocity move)\n", axis);
       }
@@ -159,6 +164,16 @@ ss motor
 
   state moving
   { 
+    /* Slightly funny syntax - check if variable was updated, if it was, 
+       update user_stop with it's latest value and then check stop condition. */
+    when (pvGetQ(user_stop) && user_stop == 1)
+    {
+      errlogSevPrintf(errlogMajor, "Sequencer: axis %i: User stop detected during home - will not define position.\n", axis);
+      if (debug) {
+        errlogSevPrintf(errlogInfo, "Sequencer: axis %i: FROM moving TO done\n", axis);
+      }
+    } state done
+  
     when (movable==1)
     { 
       if (mode==2 || mode==3) {

--- a/motorApp/MclennanSrc/homing.st
+++ b/motorApp/MclennanSrc/homing.st
@@ -47,10 +47,6 @@ syncq user_stop 100;
 PV(double, hlm, "{MOTPV}.HLM", Monitor);
 PV(double, llm, "{MOTPV}.LLM", Monitor);
 
-// Physical limit switches
-PV(int, hls, "{MOTPV}.HLS", Monitor);
-PV(int, lls, "{MOTPV}.LLS", Monitor);
-
 ss motor
 {
   state init

--- a/motorApp/MclennanSrc/homing.st
+++ b/motorApp/MclennanSrc/homing.st
@@ -2,6 +2,9 @@ program homing("MOTPV=xxx,MODE,AXIS,DEBUG")
 
 #include "seqPVmacros.h"
 
+%% #include "string.h"
+%% #include "errlog.h"
+
 char* SNLtaskName;
 int jog_forward_value, jog_reverse_value;
 assign jog_forward_value to "{MOTPV}.JOGF";
@@ -21,13 +24,27 @@ int debug;
 int mode;
 int axis;
 
+double cached_soft_high_limit = 0.0;
+double cached_soft_low_limit = 0.0;
+
 /* Turn on run-time debug messages */
 option +d;
+
+/* Make code reentrant. This is needed to run more than one instance of this program. */
+option +r;
 
 /* PV definitions */
 PV(int, home_forward_pv, "{MOTPV}.HOMF", Monitor);
 PV(int, home_reverse_pv, "{MOTPV}.HOMR", Monitor);
 PV(int, movable, "{MOTPV}.DMOV", Monitor);
+
+// Soft limits
+PV(int, hlm, "{MOTPV}.HLM", Monitor);
+PV(int, llm, "{MOTPV}.LLM", Monitor);
+
+// Physical limit switches
+PV(int, hls, "{MOTPV}.HLS", Monitor);
+PV(int, lls, "{MOTPV}.LLS", Monitor);
 
 ss motor
 {
@@ -39,10 +56,10 @@ ss motor
       mode = atoi(macValueGet("MODE"));
       axis = atoi(macValueGet("AXIS"));
       debug = atoi(macValueGet("DEBUG"));
-      printf("Sequencer: Homing mode for axis %i set to %i\n", axis, mode);
+      errlogSevPrintf(errlogInfo, "Sequencer: Homing mode for axis %i set to %i\n", axis, mode);
       
       if (debug) {
-        printf("Sequencer: Debug mode ON\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: Debug mode ON\n");
       }
     } state ready
   }
@@ -52,7 +69,7 @@ ss motor
     when (home_reverse_pv==1)
     {
       if (debug) {
-        printf("Sequencer: FROM ready TO reverse_home_requested\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: FROM ready TO reverse_home_requested\n");
       }
     } state reverse_home_requested
     
@@ -60,16 +77,25 @@ ss motor
     when ((home_forward_pv==1) && (mode==3))
     {
       if (debug) {
-        printf("Sequencer: FROM ready TO reverse_home_requested\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: FROM ready TO reverse_home_requested\n");
       }
     } state reverse_home_requested
     
     when ((home_forward_pv==1) && (mode!=3))
     {
       if (debug) {
-        printf("Sequencer: FROM ready TO forward_home_requested\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: FROM ready TO forward_home_requested\n");
       }
     } state forward_home_requested
+    
+    exit {
+      /* Cache soft limits and then remove them */
+      cached_soft_high_limit = hlm;
+      cached_soft_low_limit = llm;
+      
+      PVPUT(hlm, 999999999);
+      PVPUT(llm, -999999999);
+    }
   }
   
   state forward_home_requested
@@ -80,14 +106,14 @@ ss motor
       jog_forward_value = 1;
       pvPut(jog_forward_value);
       if (debug) {
-        printf("Sequencer: FROM forward_home_requested TO processing_move_request (constant velocity move)\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: FROM forward_home_requested TO processing_move_request (constant velocity move)\n");
       }
     } state processing_move_request
     
     /* No delay needed for modes other than 1 */
     when (!(mode==1 || mode==3)) {
       if (debug) {
-        printf("Sequencer: FROM forward_home_requested TO processing_move_request\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: FROM forward_home_requested TO processing_move_request\n");
       }
     } state processing_move_request
   }
@@ -100,14 +126,14 @@ ss motor
       jog_reverse_value = 1;
       pvPut(jog_reverse_value);
       if (debug) {
-        printf("Sequencer: FROM reverse_home_requested TO processing_move_request (constant velocity move)\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: FROM reverse_home_requested TO processing_move_request (constant velocity move)\n");
       }
     } state processing_move_request
     
     /* No delay needed for modes other than 1 and 3 */
     when (!(mode==1 || mode==3)) {
       if (debug) {
-        printf("Sequencer: FROM reverse_home_requested TO processing_move_request\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: FROM reverse_home_requested TO processing_move_request\n");
       }
     } state processing_move_request
   }
@@ -116,7 +142,7 @@ ss motor
   {
     when (movable==0) {
       if (debug) {
-        printf("Sequencer: FROM processing_move_request TO moving\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: FROM processing_move_request TO moving\n");
       }
     } state moving
   }
@@ -127,26 +153,29 @@ ss motor
     { 
       if (mode==2 || mode==3) {
         if (debug) {
-            printf("Sequencer: Setting position to zero (modes 2 and 3)\n");
+            errlogSevPrintf(errlogInfo, "Sequencer: Setting position to zero (modes 2 and 3)\n");
         }
 
-        pvGet(offset);
-        offsetval = offset;
+        if (mode==3 && (!hls) && (!lls)) {
+            errlogSevPrintf(errlogMajor, "Sequencer: Home mode 3 move complete but hardware limit not engaged. Not defining motor position.\n");
+        } else {
+            pvGet(offset);
+            offsetval = offset;
 
-        PVPUT(set, 1);
+            PVPUT(set, 1);
 
-        PVPUT(position, 0.0);
-        PVPUT(position_d, 0.0);
+            PVPUT(position, 0.0);
+            PVPUT(position_d, 0.0);
 
-        /* Reapply the offset */
-        PVPUT(offset, offsetval);
-        
-        PVPUT(set, 0);
-        
+            /* Reapply the offset */
+            PVPUT(offset, offsetval);
+            
+            PVPUT(set, 0);
+        }
 
       }
       if (debug) {
-        printf("Sequencer: FROM moving TO done\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: FROM moving TO done\n");
       }
     } state done
   }
@@ -159,8 +188,13 @@ ss motor
         jog_forward_value = 0;
         pvPut(jog_forward_value);
       }
+      
+      /* Re-apply cached soft limits */
+      PVPUT(hlm, cached_soft_high_limit);
+      PVPUT(llm, cached_soft_low_limit);
+      
       if (debug) {
-        printf("Sequencer: FROM done TO ready\n");
+        errlogSevPrintf(errlogInfo, "Sequencer: FROM done TO ready\n");
       }
     } state ready
   } 

--- a/motorApp/MclennanSrc/homing.st
+++ b/motorApp/MclennanSrc/homing.st
@@ -39,8 +39,8 @@ PV(int, home_reverse_pv, "{MOTPV}.HOMR", Monitor);
 PV(int, movable, "{MOTPV}.DMOV", Monitor);
 
 // Soft limits
-PV(int, hlm, "{MOTPV}.HLM", Monitor);
-PV(int, llm, "{MOTPV}.LLM", Monitor);
+PV(double, hlm, "{MOTPV}.HLM", Monitor);
+PV(double, llm, "{MOTPV}.LLM", Monitor);
 
 // Physical limit switches
 PV(int, hls, "{MOTPV}.HLS", Monitor);
@@ -156,23 +156,18 @@ ss motor
             errlogSevPrintf(errlogInfo, "Sequencer: Setting position to zero (modes 2 and 3)\n");
         }
 
-        if (mode==3 && (!hls) && (!lls)) {
-            errlogSevPrintf(errlogMajor, "Sequencer: Home mode 3 move complete but hardware limit not engaged. Not defining motor position.\n");
-        } else {
-            pvGet(offset);
-            offsetval = offset;
+        pvGet(offset);
+        offsetval = offset;
 
-            PVPUT(set, 1);
+        PVPUT(set, 1);
 
-            PVPUT(position, 0.0);
-            PVPUT(position_d, 0.0);
+        PVPUT(position, 0.0);
+        PVPUT(position_d, 0.0);
 
-            /* Reapply the offset */
-            PVPUT(offset, offsetval);
-            
-            PVPUT(set, 0);
-        }
-
+        /* Reapply the offset */
+        PVPUT(offset, offsetval);
+        
+        PVPUT(set, 0);
       }
       if (debug) {
         errlogSevPrintf(errlogInfo, "Sequencer: FROM moving TO done\n");

--- a/motorApp/MclennanSrc/homing.st
+++ b/motorApp/MclennanSrc/homing.st
@@ -149,6 +149,9 @@ ss motor
       if (debug) {
         errlogSevPrintf(errlogInfo, "Sequencer: axis %i: FROM processing_move_request TO moving\n", axis);
       }
+
+      pvFlushQ(user_stop);
+      
     } state moving
     
     /* If move doesn't start within 10 seconds, cancel home (we may be in a state where we can't move) */


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/4908

- Don't redefine position when hitting soft limits (remove soft limits during home)
- Don't redefine position if the user stops a home mid-way through
- If a homing move doesn't start within 10 seconds, cancel it (we may be in a state where the motor can't move)
- Log to EPICS logger rather than just printf, so that it goes to IOC log with timestamps etc