### PR TITLE
Disable position initialisation on startup

### DIFF
--- a/motorApp/MotorSrc/devMotorAsyn.c
+++ b/motorApp/MotorSrc/devMotorAsyn.c
@@ -171,7 +171,7 @@ static void init_controller(struct motorRecord *pmr, asynUser *pasynUser )
     double position = pPvt->status.position;
     double rdbd = (fabs(pmr->rdbd) < fabs(pmr->mres) ? fabs(pmr->mres) : fabs(pmr->rdbd) );
     double encRatio[2] = {pmr->mres, pmr->eres};
-    int use_rel = (pmr->rtry != 0 && pmr->rmod != motorRMOD_I && (pmr->ueip || pmr->urip));
+    int use_rel = 0; /*(pmr->rtry != 0 && pmr->rmod != motorRMOD_I && (pmr->ueip || pmr->urip));*/
 
     /*Before setting position, set the correct encoder ratio.*/
     start_trans(pmr);

--- a/motorApp/MotorSrc/motordevCom.cc
+++ b/motorApp/MotorSrc/motordevCom.cc
@@ -196,7 +196,7 @@ motor_init_record_com(struct motorRecord *mr, int brdcnt, struct driver_table *t
     double ep_mp[2];            /* encoder pulses, motor pulses */
     int rtnStat;
     msta_field msta;
-    bool use_rel = (mr->rtry != 0 && mr->rmod != motorRMOD_I && (mr->ueip || mr->urip));
+    bool use_rel = false; //(mr->rtry != 0 && mr->rmod != motorRMOD_I && (mr->ueip || mr->urip));
 
     /* allocate space for private field - an motor_trans structure */
     mr->dpvt = (struct motor_trans *) malloc(sizeof(struct motor_trans));


### PR DESCRIPTION
Stop automatic position initialisation on boot, this reverts to motor record 6-9 behaviour

See ISISComputingGroup/IBEX#4921