### PR TITLE
Added initial val on periodic polling PV

### DIFF
--- a/motorApp/Db/periodic_polling.db
+++ b/motorApp/Db/periodic_polling.db
@@ -4,5 +4,6 @@ record(ao, "$(P)$(M):SCAN") {
   field(DESC, "Polls the motor position")
   field(OUT, "$(P)$(M).STUP PP")
   field(OVAL, "1")
+  field(VAL, "1")
   field(SDIS, "$(P)$(M).MOVN")
 }


### PR DESCRIPTION
Fixes mclennan IOC system test. Oddly I can't reproduce the issue locally but on the build server the SCAN PV will not process when it doesn't have a valid initial VAL.