### PR TITLE
Fix negative backlash with relative moves in a negative direction

### DIFF
--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -2410,7 +2410,7 @@ static RTN_STATUS do_work(motorRecord * pmr, CALLBACK_VALUE proc_ind)
                 }
                 /* IF move is in preferred direction, AND, current position is within backlash range. */
                 else if ((preferred_dir == true) &&
-                         ((use_rel == true  && relbpos <= 1.0) ||
+                         ((use_rel == true  && ((pmr->bdst >= 0 && relbpos <= 1.0) || (pmr->bdst < 0 && relbpos >= 1.0))) ||
                           (use_rel == false && (fabs(newpos - currpos) <= rbdst1))
                          )
                         )


### PR DESCRIPTION
A negative BDST was correctly applied to negative direction moves
if moves are absolute. When retries are enabled all moves become
relative and backlash was not applied correctly for negative direction
moves.

See ISISComputingGroup/IBEX#6910 and ISISComputingGroup/IBEX#6919