### PR TITLE
Move AXES_NUM to new db

### DIFF
--- a/motorApp/Db/Makefile
+++ b/motorApp/Db/Makefile
@@ -39,6 +39,7 @@ DB += ACRAuxBoRBV.template
 DB += TransPos.db
 DB += motorUtil.db
 DB += motorStatus.db
+DB += motorController.db
 DB += asyn_motor.db
 DB += profileMoveController.template
 DB += profileMoveAxis.template

--- a/motorApp/Db/motorController.db
+++ b/motorApp/Db/motorController.db
@@ -1,0 +1,7 @@
+## pvs that should be available per controller
+## Q is normally MOT:MTRxx:
+
+record(longin, "$(P)$(Q)AXES_NUM") {
+  field(DESC, "number of axes on controller")
+  field(VAL, "$(AXES_NUM=8)")
+}

--- a/motorApp/Db/motorUtil.db
+++ b/motorApp/Db/motorUtil.db
@@ -83,6 +83,8 @@ $(IFIOC_SM300_01=#)  field(OUTA, "$(PVPREFIX)CS:MOT:_MOVING1.K CA")
 ## _MOVING2.A is used by reflectometry ioc
 $(IFIOC_NWPRTXPS_01=#)  field(OUTA, "$(PVPREFIX)CS:MOT:_MOVING2.B CA")
 $(IFIOC_TWINCAT_01=#)  field(OUTA, "$(PVPREFIX)CS:MOT:_MOVING2.C CA")
+$(IFIOC_GALILMUL_01=#)  field(OUTA, "$(PVPREFIX)CS:MOT:MOVING.D CA")
+$(IFIOC_GALILMUL_02=#)  field(OUTA, "$(PVPREFIX)CS:MOT:MOVING.E CA")
 }
 
 # force periodic processing to catch up any missing, shouldn't
@@ -115,11 +117,6 @@ record(waveform, "$(P)movingDiff") {
   field(DESC, "Motor w/ last dmov change")
   field(NELM, "62")
   field(FTVL, "CHAR")
-}
-
-record(ai, "$(PVPREFIX)MOT:MTR$(MTRCTRL):AXES_NUM") {
-  field(DESC, "The num of axes on the controller")
-  field(VAL, "$(AXES_NUM=8)")
 }
 
 #! Further lines contain data used by VisualDCT


### PR DESCRIPTION
Move AXES_NUM to new DB to avoid re-loading motorUtil that is a per IOC not per controller DB

See ISISComputingGroup/IBEX#6923
